### PR TITLE
Support can-define/map as a viewModel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Bitovi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,26 @@
+
+Thank you for contributing to Can-React!  If you need any help setting up a CanJS development environment and fixing Can-React bugs, please reach out to us on the [canjs/canjs Gitter channel](https://gitter.im/canjs/canjs) or email (contact@bitovi.com).  We will happily walk you through setting up a the environment, creating a test, and submitting a pull request.
+
+## Reporting Bugs
+
+To report a bug, please visit [GitHub Issues](/bigab/can-react/issues).
+
+When filing a bug, it is helpful to include small examples using tools like [JSBin][1] or [CodePen][2].
+
+Search for previous tickets, if there is one add to that one rather than creating another. You can also post on the [Forums](http://forums.donejs.com/c/canjs) or talk to us in [gitter canjs/canjs channel](https://gitter.im/canjs/canjs).
+
+## Contributing
+
+When contributing, please include tests with new features or bug fixes in a feature branch until you're ready to submit the code for consideration; then push to the fork, and submit a pull request. More detailed steps are as follows:
+
+1. Navigate to your clone of the Can-React repository - `cd /path/to/can-react`
+2. Create a new feature branch - `git checkout -b lifecycle-fix`
+3. Make some changes
+4. Update tests to accomodate your changes
+5. Run tests and make sure they pass in all browsers
+6. Update documentation if necessary
+7. Push your changes to your remote branch - `git push origin lifecycle-fix`
+8. Submit a pull request! Navigate to [Pull Requests](/bigab/can-react/pulls) and click the 'New Pull Request' button. Fill in some details about your potential patch including a meaningful title. When finished, press "Send pull request". The team will be notified about your submission and let you know of any problems or targeted release date.
+
+[1]: https://jsbin.com/
+[2]: https://codepen.io/

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     ]
   },
   "dependencies": {
-    "can": "^2.3.24",
+    "can-compute": "^3.0.0-pre.10",
+    "can-define": "^0.7.17",
     "react": "^15.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "bigab@live.ca",
     "url": "adamlbarrett.ca"
   },
+  "license": "MIT",
   "scripts": {
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "can-compute": "^3.0.0-pre.10",
-    "can-define": "^0.7.17",
+    "can-define": "^0.7.24",
     "react": "^15.2.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -1,33 +1,88 @@
-### A New Proposal for
 # Can-React
 
-### An Explanation:
+### @bigab/can-react
 
-#### Standing on the shoulders of giants
+[![Build Status](https://travis-ci.org/BigAB/can-react.png?branch=master)](https://travis-ci.org/BigAB/can-react)
 
-Redux, is a functional programming style library for managing state in a single store. It uses a pattern of composable pure functions called reducers to represent the state of the app, and uses actions to modify that state and produce updates that a view layer can bind to. React-Redux is a library to connect Redux to the wildly popular library React.
 
-React-Redux has popularized the idea of separating React components into 2 types: Container Components and Presentational Components (previously know as smart components and dumb components). **Presentational Components** are pure react, using props and sometimes state, to decide what to render and when to update the DOM, they are generally highly re-usable and are the favoured choice for components, usually making up the majority of the components in a given app. **Container Components** on the other hand, are “Higher Order Components”, that do not provide their own DOM rendering but rather extend an existing Presentational Component, connecting it to a data store and updating props when the connected state updates.
+Connect observable view-models to React [presentational components][1] to create auto rendering [container components][1].
 
-React-Redux exports a single function `connect()` and a single component `<Provider />` for taking Presentational Components and “upgrading” and extending them into Container Components.
+## Install
 
-The `connect` function accepts a React Component and some mapping functions, mapping state and action creators to the React `props` the component is expecting to receive. When the stores state is updated the component “receives new props” and re-renders accordingly. When user actions should modify that state, the interaction callbacks provided by props in Presentational Components are mapped to “action creators” which then get sent into the root reducer and fall throughout the reducer tree, and eventually the root reducer returns a new state and the app is re-rendered.
+#### ES6
 
-The `<Provider />` component wraps the entire app, and is used to enforce the “single-store” philosophy of react-redux, by providing that store to all the container components.
-
-### Yeah? So…?
-
-Can-React follows the pattern popularized by react-redux, and provide users with a `connect()` function for extending React Presentational Components into Container Components, by providing `connect` with a `mapToProps` function and a presentational component, just like Redux does. The `mapToProps` function will get converted to a compute, so when any observable read inside the compute emits a change, or if new props get set on the Container Component, it will update the wrapped/connected presentational component instance with new derived props.
-
-### Implementation Details
-
-Currently the only API needed, and only one exported in the POC (proof of concept) is a single function called `connect`.
-
-```javascript
-connect( mapToProps {function}, Component {React Component} )
+```js
+import { connect } from '@bigab/can-react';
 ```
 
-`connect()` takes 2 arguments. The first is **mapToProps**, a function that will return an object that the component instance will receive as `props`, and the second argument is a **Presentational Component** constructor function (a.k.a. a class or just component in React). The `connect()` function returns a **Container Component** which can then be imported and used in any react component as usual.
+#### CommonJS
+
+```js
+var connect = require("@bigab/can-react").connect;
+```
+
+## Usage
+`save-button.js`
+```js
+import { connect } from '@bigab/can-react';
+import Button from './button.jsx';
+import DefineMap from 'can-define/map/';
+import Item from '../models/items';
+
+let items = Items.getList({ selected: true });
+
+export const ViewModel = DefineMap.extend({
+  text: {
+    get() {
+      return `Save ${items.length} items`;
+    }
+  },
+  onClick() {
+    items.saveAllItems();
+  }
+});
+
+export default connect( ViewModel, Button );
+```
+
+## API
+#### `connect( {ViewModel|mapToProps}, Component ) `
+Connect a view-model class or mapToPros function to React [presentational components][1]
+
+`connect()` takes 2 arguments. The first is either a **mapToProps** function, a function that will return an object that the component instance will receive as `props`, or a **ViewModel** constructor function, which is an extended [can-define/map][2]. The second argument is a **Presentational Component** constructor function (a.k.a. a class or just component in React). The `connect()` function returns a **Container Component** which can then be imported and used in any react component or render function as usual.
+
+##### ViewModel `{constructor function}`
+A [DefineMap][2] constructor function.
+
+Every instance of the returned component will generate an instance of the viewModel and provide props to the connected component based on the serialized Map instance.
+
+The `ViewModel` instance will be initialized with the `props` passed into the Container Component. Whenever the container component will receive new `props`, the `props` object is passed to the viewModels `.set()` method, which may in turn cause an observable change event, which will re-run the serialization process and provide the connected component new props, which may cause a new render.
+
+Methods on the view model, and copied onto the serialized props object and bound to the viewModel, so that they may be used as callbacks for the connected component, while still being called with the correct context.
+
+#### Example:
+```javascript
+import { connect } from '@bigab/can-react';
+import DefineMap from 'can-define/map/map';
+import TodoComponent from 'components/todo.jsx';
+import Todo from 'models/todo';
+
+const ViewModel = DefineMap.extend({
+  showOnlyCompleted: 'boolean',
+  todos: {
+    value: Todo.getList( { completed: this.showOnlyCompleted } ),
+    serialize: true
+  }
+  addTodo(formValues) {
+    new Todo(formValues).save()
+  }
+});
+
+export default connect( ViewModel, TodoComponent );
+```
+
+##### mapToProps `{function}`
+A function that receives props as an argument and returns `props` to be sent to the _connected component_. This `mapTpProps` function will be converted into a [compute][3] and any changes made to _observable_ derived values within this function will re-run this function to calculate the new props and pass them into the connected component.
 
 The **mapToProps** function has one parameter, `ownProps`, which are the props that would have normally been passed into this component instance, as defined by the owner template (JSX).
 
@@ -51,77 +106,36 @@ connect( ownProps => {
 }, MyComponent ) ;
 ```
 
-
-# @bigab/can-react
-
-[![Build Status](https://travis-ci.org/BigAB/can-react.png?branch=master)](https://travis-ci.org/bigab/can-react)
-
-
-## Usage
-
-### ES6 use
-
-With StealJS, you can import this module directly in a template that is autorendered:
-
-```js
-import plugin from '@bigab/can-react';
-```
-
-### CommonJS use
-
-Use `require` to load `@bigab/can-react` and everything else
-needed to create a template that uses `@bigab/can-react`:
-
-```js
-var plugin = require("@bigab/can-react");
-```
-
-## AMD use
-
-Configure the `can` and `jquery` paths and the `@bigab/can-react` package:
-
-```html
-<script src="require.js"></script>
-<script>
-	require.config({
-	    paths: {
-	        "jquery": "node_modules/jquery/dist/jquery",
-	        "can": "node_modules/canjs/dist/amd/can"
-	    },
-	    packages: [{
-		    	name: '@bigab/can-react',
-		    	location: 'node_modules/@bigab/can-react/dist/amd',
-		    	main: 'lib/bigab-can-react'
-	    }]
-	});
-	require(["main-amd"], function(){});
-</script>
-```
-
-### Standalone use
-
-Load the `global` version of the plugin:
-
-```html
-<script src='./node_modules/@bigab/can-react/dist/global/@bigab/can-react.js'></script>
-```
+##### Component `{react component}`
+Any react component, usually a [presentational component][1]
 
 ## Contributing
+[Contributing](./contributing.md)
 
-### Making a Build
-
-To make a build of the distributables into `dist/` in the cloned repository run
-
-```
-npm install
-node build
-```
 
 ### Running the tests
 
-Tests can run in the browser by opening a webserver and visiting the `test.html` page.
+Tests can run in the browser by opening a webserver and visiting the `src/test/test.html` page.
 Automated tests that run the tests from the command line in Firefox can be run with
 
 ```
 npm test
 ```
+
+## Why Can-React?
+
+Can-React follows the pattern popularized by [react-redux][4], and provide users with a `connect()` function for extending React Presentational Components into Container Components, by providing `connect` with either a `mapToProps` function or more commonly a `ViewModel`  constructor function, which is an extended [DefineMap][2] class, along with a presentational component, just like react-redux does.
+
+The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, it will be serialized and sent into the connected component as props, forcing an update/render.
+
+The `mapToProps` function will get converted to a compute, so when any observable read inside the compute emits a change (or if new props get set on the Container Component), it will update the wrapped/connected presentational component instance with new derived props.
+
+By following the patterns established by react-redux, but avoiding the complexity of pure-functional programing, reducer composition, immutability, and the single store paradigm, we hope to offer a familiar, powerful, but far simpler solution to creating great backing data stores for your react app.
+
+## License
+[License](./LICENSE)
+
+[1]: https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8
+[2]: https://canjs.github.io/canjs/doc/can-define/map/map.html
+[3]: https://canjs.github.io/canjs/doc/can-compute.html
+[4]: https://github.com/reactjs/react-redux

--- a/src/can-react.js
+++ b/src/can-react.js
@@ -1,27 +1,46 @@
 import React from 'react';
-import compute from 'can/compute/compute';
+import compute from 'can-compute';
+import DefineMap from "can-define/map/";
 
-export function connect(mapToProps, ComponentToConnect) {
-  const connectDisplayName = `Connected(${ getDisplayName(ComponentToConnect) })`;
-
-  const mapToState = (props) => {
-    return Object.assign( {}, props, mapToProps(props) );
-  };
+export function connect( MapToProps, ComponentToConnect ) {
 
   class ConnectedComponent extends React.Component {
 
     constructor(props) {
       super(props);
       this.propsCompute = compute(props);
-      this.compute = compute(() => {
-        return mapToState( this.propsCompute() );
-      });
-      this.state = this.compute();
+
+      if ( MapToProps.prototype instanceof DefineMap ) {
+        this.viewModel = new MapToProps( this.propsCompute() );
+        this.mapToState = this.createMapToStateWithViewModel( this.viewModel );
+      } else {
+        this.mapToState = this.createMapToStateWithFunction( MapToProps )
+      }
+
+      this.state = { propsForChild: this.mapToState() };
       let batchNum;
-      this.compute.bind("change", (ev, newVal) => {
+      this.mapToState.bind("change", (ev, newVal) => {
         if(!ev.batchNum || ev.batchNum !== batchNum) {
-          this.setState(newVal);
+          this.setState({ propsForChild: newVal });
         }
+      });
+    }
+
+    createMapToStateWithViewModel( vm ) {
+      return compute(() => {
+        vm.set( this.propsCompute() );
+        const props = vm.serialize();
+        getMethodNames( vm ).forEach( methodName => {
+          props[methodName] = vm[methodName].bind(vm);
+        });
+        return props;
+      });
+    }
+
+    createMapToStateWithFunction( func ) {
+      return compute(() => {
+        const props = this.propsCompute();
+        return Object.assign( {}, props, func(props) );
       });
     }
 
@@ -30,16 +49,30 @@ export function connect(mapToProps, ComponentToConnect) {
     }
 
     render() {
-      return React.createElement(ComponentToConnect, this.state);
+      return React.createElement(ComponentToConnect, this.state.propsForChild);
     }
 
   }
 
-  ConnectedComponent.displayName = connectDisplayName;
+  ConnectedComponent.displayName = `Connected(${ getDisplayName(ComponentToConnect) })`;
 
   return ConnectedComponent;
 }
 
 function getDisplayName(ComponentToConnect) {
   return ComponentToConnect.displayName || ComponentToConnect.name || 'Component';
+}
+
+function getMethodNames( obj ) {
+  const result = [];
+  for (var key in obj) {
+    try {
+      if (typeof( obj[key] ) == "function") {
+        result.push( key );
+      }
+    } catch (err) {
+      // do nothing
+    }
+  }
+  return result;
 }

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
 import { connect } from '../can-react';
 import React from 'react';
-import compute from 'can/compute/';
+import compute from 'can-compute';
 import ReactTestUtils from 'react-addons-test-utils';
+import DefineMap from "can-define/map/";
 import 'steal-mocha';
 const assert = chai.assert;
 
@@ -21,53 +22,127 @@ describe('can-react', function(){
       shallowRenderer = ReactTestUtils.createRenderer();
     });
 
-    it('should not (by default) render additional dom nodes that the ones from the extended Presentational Component', () => {
+    describe('with a map to props function', () => {
 
-      const ConnectedComponent = connect( () => ({ value: 'bar' }), TestComponent );
+      it('should not (by default) render additional dom nodes that the ones from the extended Presentational Component', () => {
 
-      shallowRenderer.render( React.createElement( ConnectedComponent, { value: 'foo' } ) );
+        const ConnectedComponent = connect( () => ({ value: 'bar' }), TestComponent );
 
-      const result = shallowRenderer.getRenderOutput();
+        shallowRenderer.render( React.createElement( ConnectedComponent, { value: 'foo' } ) );
 
-      assert.equal(result.type, TestComponent); // not ConnectedComponent
-      assert.equal(result.props.value, 'bar'); // not 'foo'
+        const result = shallowRenderer.getRenderOutput();
+
+        assert.equal(result.type, TestComponent); // not ConnectedComponent
+        assert.equal(result.props.value, 'bar'); // not 'foo'
+
+      });
+
+      it('should update the component whenever an observable read inside the mapToProps function emits a change event', function() {
+        const observable = compute('Inital Value');
+        const ConnectedComponent = connect( () => ({ value: observable() }), TestComponent );
+
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+        const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
+
+        assert.equal(childComponent.props.value, 'Inital Value');
+        observable('new value');
+        assert.equal(childComponent.props.value, 'new value');
+
+      });
+
+      it('should update the component when new props are recieved', function() {
+        const observable = compute('Inital Observable Value');
+        const ConnectedComponent = connect( ({ propValue }) => ({ value: observable(), propValue }), TestComponent );
+        const WrappingComponent = React.createClass({
+          getInitialState() {
+            return { propValue: 'Initial Prop Value' };
+          },
+          changeState() {
+            this.setState( { propValue: 'New Prop Value' } );
+          },
+          render() {
+            return <ConnectedComponent propValue={ this.state.propValue } />;
+          }
+        });
+
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( WrappingComponent ) );
+        const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
+
+        assert.equal(childComponent.props.propValue, 'Initial Prop Value');
+        result.changeState();
+        assert.equal(childComponent.props.propValue, 'New Prop Value');
+      });
 
     });
 
-    it('should update the component whenever an observable read inside the mapToProps function emits a change event', function() {
-      const observable = compute('Inital Value');
-      const ConnectedComponent = connect( () => ({ value: observable() }), TestComponent );
+    describe('with can-define constructor function', () => {
 
-      const result = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
-      const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
-
-      assert.equal(childComponent.props.value, 'Inital Value');
-      observable('new value');
-      assert.equal(childComponent.props.value, 'new value');
-
-    });
-
-    it('should update the component when new props are recieved', function() {
-      const observable = compute('Inital Observable Value');
-      const ConnectedComponent = connect( ({ propValue }) => ({ value: observable(), propValue }), TestComponent );
-      const WrappingComponent = React.createClass({
-        getInitialState() {
-          return { propValue: 'Initial Prop Value' };
+      const DefinedViewModel = DefineMap.extend({
+        foo: {
+          type: 'string',
+          value: 'foo'
         },
-        changeState() {
-          this.setState( { propValue: 'New Prop Value' } );
+        bar: 'string',
+        foobar: {
+          get() {
+            return this.foo + this.bar;
+          },
+          serialize: true
         },
-        render() {
-          return <ConnectedComponent propValue={ this.state.propValue } />;
+        callback() {
+          return this;
         }
       });
 
-      const result = ReactTestUtils.renderIntoDocument( React.createElement( WrappingComponent ) );
-      const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
+      it('should assign a property to the component called `viewModel` with an instance of ViewModel as the value', () => {
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+        assert.ok( result.viewModel instanceof DefinedViewModel );
+      });
 
-      assert.equal(childComponent.props.propValue, 'Initial Prop Value');
-      result.changeState();
-      assert.equal(childComponent.props.propValue, 'New Prop Value');
+      it('should pass a props object with copied methods, that have the correct context (the viewmodel) to be used as callbacks', () => {
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+        const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
+        assert.equal(childComponent.props.callback(), result.viewModel);
+      });
+
+      it('should update whenever any observable property on the viewModel instance changes', function() {
+
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent, { bar: 'bar', baz: 'bam' } ) );
+        const childComponent = ReactTestUtils.scryRenderedComponentsWithType( result, TestComponent )[0];
+
+        assert.equal(childComponent.props.foobar, 'foobar');
+        result.viewModel.foo = 'MMM';
+        assert.equal(childComponent.props.foobar, 'MMMbar');
+
+      });
+
+      it('should update the component when new props are recieved', function() {
+        const observable = compute('Inital Observable Value');
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const WrappingComponent = React.createClass({
+          getInitialState() {
+            return { propValue: 'Initial Prop Value' };
+          },
+          changeState() {
+            this.setState( { propValue: 'New Prop Value' } );
+          },
+          render() {
+            return <ConnectedComponent propValue={ this.state.propValue } />;
+          }
+        });
+
+        const result = ReactTestUtils.renderIntoDocument( React.createElement( WrappingComponent ) );
+        const childComponent = ReactTestUtils.scryRenderedComponentsWithType(result, TestComponent)[0];
+
+        assert.equal(childComponent.props.propValue, 'Initial Prop Value');
+        result.changeState();
+        assert.equal(childComponent.props.propValue, 'New Prop Value');
+      });
+
     });
 
   });


### PR DESCRIPTION
- import can-define and can-compute instead of can
- accept a can-define/map constructor function as a mapToProps argument
- create props for connected component by serializing viewModel and copying bound methods over
